### PR TITLE
PN-4348 Permission model and user data.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,28 @@
 import { Backdrop, CircularProgress } from '@mui/material';
+import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
+import { getUser } from './Authentication/auth';
 import { ConfirmationProvider } from './components/confirmationDialog/ConfirmationProvider';
 import SnackbarComponent from './components/snackbar/SnackbarComponent';
+import { useCurrentUser } from './hooks/useCurrentUser';
 import Router from './navigation/Router';
 import { opened } from "./redux/spinnerSlice";
 
 function App() {
   const openedSpinner = useSelector(opened);
+
+  const { setCurrentUser } = useCurrentUser();
+
+  /**
+   * fetch user data and let the hook store it
+   */
+  useEffect(() => {
+    getUser().then((userData) => {
+      setCurrentUser(userData);
+    });
+  }, [setCurrentUser]);
+
 
   return (
     <div>

--- a/src/Authentication/auth.tsx
+++ b/src/Authentication/auth.tsx
@@ -2,6 +2,7 @@ import awsmobile from "./aws-exports";
 import Amplify, { Auth } from "aws-amplify";
 import { setStorage, resetStorage, deleteStorage } from "./storage";
 import { CognitoUser } from "@aws-amplify/auth";
+import { UserData } from "../model/user-permission";
 
 type Props = {
   /**
@@ -99,12 +100,14 @@ const changePassword = (user: any, newPassword: string): Promise<any> => {
     });
 };
 
-const getUser = async (): Promise<any> => {
+const getUser = async (): Promise<UserData> => {
   return await Auth.currentAuthenticatedUser()
     .then(async (user) => {
       return await Auth.userAttributes(user).then((userAttr) => {
-        return userAttr.find((attr) => attr.Name === "email")?.Value;
-      });
+        return {
+          email: userAttr.find((attr) => attr.Name === "email")?.Value,
+          permissions: [],
+      }});
     })
     .catch((error: any) => {
       throw error;

--- a/src/components/forms/login/LoginForm.tsx
+++ b/src/components/forms/login/LoginForm.tsx
@@ -17,6 +17,7 @@ import * as snackbarActions from "../../../redux/snackbarSlice";
 import { useDispatch } from "react-redux";
 import * as spinnerActions from "../../../redux/spinnerSlice";
 import { MonogramPagoPACompany } from "@pagopa/mui-italia";
+import { useCurrentUser } from "../../../hooks/useCurrentUser";
 
 /**
  * default values of the form fields
@@ -64,6 +65,10 @@ const LoginForm = ({ setUser }: any) => {
    */
   const navigate = useNavigate();
 
+  // obtain the function which sets the user data 
+  // to pass it to the login function, so the login does set user data
+  const { setCurrentUser } = useCurrentUser();
+
   /**
    * function handling the form submitting
    * @param data the data from the form
@@ -71,7 +76,7 @@ const LoginForm = ({ setUser }: any) => {
   /* istanbul ignore next */
   const onSubmit = async (data: { [x: string]: string }) => {
     dispatch(spinnerActions.updateSpinnerOpened(true));
-    await login({ email: data.email, password: data.password })
+    await login({ email: data.email, password: data.password, setCurrentUser })
       .then((user: { [key: string]: any }) => {
         if (user.challengeName === "NEW_PASSWORD_REQUIRED") {
           dispatch(spinnerActions.updateSpinnerOpened(false));

--- a/src/components/forms/search/__test__/SearchForm.test.tsx
+++ b/src/components/forms/search/__test__/SearchForm.test.tsx
@@ -8,17 +8,11 @@ import { screen, act, cleanup } from "@testing-library/react";
 import { reducer } from "../../../../mocks/mockReducer";
 import SearchForm from "../SearchForm";
 import userEvent from "@testing-library/user-event";
-import * as auth from "../../../../Authentication/auth";
 
 describe("SearchForm", () => {
   afterEach(cleanup);
 
   beforeEach(() => {
-    jest.spyOn(auth, "getUser").mockImplementation(() => {
-      return new Promise((resolve, reject) => {
-        return resolve("test");
-      });
-    });
     reducer(<SearchForm />);
   });
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -12,15 +12,16 @@ import {
   DialogTitle,
   Tooltip,
 } from "@mui/material";
-import { useEffect, useState } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { infoMessages } from "../../helpers/messagesConstants";
 import { Divider, Grid, Typography } from "@material-ui/core";
-import { logout, getUser } from "../../Authentication/auth";
+import { logout } from "../../Authentication/auth";
 import { useDispatch } from "react-redux";
 import * as spinnerActions from "../../redux/spinnerSlice";
 import NavigationMenu from "../navigationMenu/NavigationMenu";
 import PermIdentityIcon from "@mui/icons-material/PermIdentity";
+import { useCurrentUser } from "../../hooks/useCurrentUser";
 
 /**
  * General component presenting the header of the app.
@@ -31,7 +32,9 @@ const Header = () => {
    */
   const [open, setOpen] = useState(false);
 
-  const [email, setEmail] = useState("no email");
+  const { currentUser } = useCurrentUser();
+  
+  const email = useMemo(() => currentUser?.email || "no email", [currentUser]);
 
   const navigate = useNavigate();
 
@@ -39,15 +42,6 @@ const Header = () => {
    * dispatch redux actions
    */
   const dispatch = useDispatch();
-
-  /**
-   * get the user email
-   */
-  useEffect(() => {
-    getUser().then((email) => {
-      setEmail(email);
-    });
-  }, []);
 
   /**
    * Function closing the confirmation modal

--- a/src/contexts/UserContext.ts
+++ b/src/contexts/UserContext.ts
@@ -1,0 +1,14 @@
+import { createContext } from "react";
+import { UserData } from "../model/user-permission";
+
+export interface UserContextData {
+    currentUser: UserData | null,
+    setCurrentUser: (u: UserData) => void,
+}
+
+const initialUserContextValue: UserContextData = {
+    currentUser: null,
+    setCurrentUser: (_1) => {}
+}
+
+export const UserContext = createContext(initialUserContextValue);

--- a/src/contexts/UserContextProvider.tsx
+++ b/src/contexts/UserContextProvider.tsx
@@ -1,0 +1,11 @@
+import { ReactNode, useState } from "react"
+import { UserData } from "../model/user-permission"
+import { UserContext } from "./UserContext";
+
+export function UserContextProvider(props: { children: ReactNode }) {
+    const [currentUser, setCurrentUser] = useState<UserData | null>(null);
+    
+    return <UserContext.Provider value={{currentUser, setCurrentUser}}>
+        {props.children}
+    </UserContext.Provider>
+}

--- a/src/hooks/useCurrentUser.ts
+++ b/src/hooks/useCurrentUser.ts
@@ -1,0 +1,9 @@
+import { useContext } from "react";
+import { UserContext } from "../contexts/UserContext";
+
+// added for PN-4348
+export function useCurrentUser() {
+  const userContext = useContext(UserContext);
+
+  return { currentUser: userContext.currentUser, setCurrentUser: userContext.setCurrentUser };
+}

--- a/src/hooks/useHasPermissions.ts
+++ b/src/hooks/useHasPermissions.ts
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+import { Permission } from "../model/user-permission";
+import { useCurrentUser } from "./useCurrentUser";
+
+// added for PN-4348 and PN-4461
+export function useHasPermissions(requiredPermissions: Array<Permission>) {
+  const { currentUser } = useCurrentUser();
+
+  const hasAllPermissions: boolean = useMemo(
+    () => requiredPermissions.every(perm => currentUser?.permissions.includes(perm)), 
+    [currentUser, requiredPermissions]
+  );
+
+  return hasAllPermissions;
+}

--- a/src/hooks/useHasPermissions.ts
+++ b/src/hooks/useHasPermissions.ts
@@ -11,5 +11,9 @@ export function useHasPermissions(requiredPermissions: Array<Permission>) {
     [currentUser, requiredPermissions]
   );
 
-  return hasAllPermissions;
+  // An anonymous (i.e. non logged) user cannot access to any route
+  // which asks for permissions, even if the set of permissions is empty.
+  // In this way we can set the empty set of permissions to routes which can be accessible
+  // for any logged user, but not for anonymous access.
+  return !!sessionStorage.getItem("token") && hasAllPermissions;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ import { store } from "./redux/store";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { it } from "date-fns/locale";
+import { UserContextProvider } from "./contexts/UserContextProvider";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
@@ -20,10 +21,12 @@ root.render(
       <ThemeProvider theme={theme}>
         {/* for date formatting in italian style */}
         <LocalizationProvider locale={it} dateAdapter={AdapterDateFns}>
-          <CssBaseline />
-          <Suspense fallback="loading...">
-            <App />
-          </Suspense>
+          <UserContextProvider>
+            <CssBaseline />
+            <Suspense fallback="loading...">
+              <App />
+            </Suspense>
+          </UserContextProvider>
         </LocalizationProvider>
       </ThemeProvider>
     </Provider>

--- a/src/model/user-permission.ts
+++ b/src/model/user-permission.ts
@@ -1,0 +1,14 @@
+export enum Permission {
+  LOG_EXTRACT_READ = 'log-extract-read',
+  API_KEY_READ = 'api-key-read',
+  API_KEY_WRITE = 'api-key-write',
+  LOG_DOWNTIME_READ = 'log-downtime-read',
+  LOG_DOWNTIME_WRITE = 'log-downtime-write',
+  TENDER_READ = 'tender-read',
+  TENDER_WRITE = 'tender-write',
+};
+
+export interface UserData {
+  email?: string;
+  permissions: Array<Permission>;
+}

--- a/src/navigation/PrivateRoute.tsx
+++ b/src/navigation/PrivateRoute.tsx
@@ -1,8 +1,9 @@
 import { Navigate } from "react-router-dom";
+import { useHasPermissions } from "../hooks/useHasPermissions";
+import { Permission } from "../model/user-permission";
 
-const PrivateRoute = ({ condition, children }: any) => {
-  let accepted = sessionStorage.getItem(condition) ? true : false;
-
+const PrivateRoute = ({ roles, children }: { roles: Array<Permission>, children: JSX.Element }): JSX.Element => {
+  const accepted = useHasPermissions(roles);
   return accepted ? children : <Navigate to="/" replace={true} />;
 };
 

--- a/src/navigation/Router.tsx
+++ b/src/navigation/Router.tsx
@@ -30,7 +30,7 @@ function Router() {
       <Route
         path="/search"
         element={
-          <PrivateRoute roles={[Permission.API_KEY_READ]}>
+          <PrivateRoute roles={[]}>
             <SearchPage />
           </PrivateRoute>
         }
@@ -39,20 +39,20 @@ function Router() {
       <Route
         path={TENDERS_TABLE_ROUTE}
         element={
-          <PrivateRoute roles={[Permission.API_KEY_READ]}>
+          <PrivateRoute roles={[]}>
             <TenderPage />
           </PrivateRoute>
         }
       />
       <Route path={CREATE_TENDER_ROUTE}>
         <Route path=":tenderCode" element={
-          <PrivateRoute roles={[Permission.API_KEY_READ]}>
+          <PrivateRoute roles={[]}>
             <FormTenderPage />
           </PrivateRoute>}
         />
 
         <Route path="" element={
-          <PrivateRoute roles={[Permission.API_KEY_READ]}>
+          <PrivateRoute roles={[]}>
             <FormTenderPage />
           </PrivateRoute>}
         />
@@ -61,7 +61,7 @@ function Router() {
       <Route
         path={CREATE_TENDER_ROUTE}
         element={
-          <PrivateRoute roles={[Permission.API_KEY_READ]}>
+          <PrivateRoute roles={[]}>
             <FormTenderPage />
           </PrivateRoute>
         }
@@ -69,7 +69,7 @@ function Router() {
       <Route
         path="/monitoring"
         element={
-          <PrivateRoute roles={[Permission.API_KEY_READ]}>
+          <PrivateRoute roles={[]}>
             <MonitorPage />
           </PrivateRoute>
         }
@@ -77,7 +77,7 @@ function Router() {
       <Route
         path={routes.AGGREGATES}
         element={
-          <PrivateRoute roles={[Permission.API_KEY_READ]}>
+          <PrivateRoute roles={[]}>
             <AggregatesPage />
           </PrivateRoute>
         }
@@ -85,7 +85,7 @@ function Router() {
       <Route
         path={routes.UPDATE_AGGREGATE}
         element={
-          <PrivateRoute roles={[Permission.API_KEY_READ]}>
+          <PrivateRoute roles={[]}>
             <AggregateDetailPage />
           </PrivateRoute>
         }
@@ -93,7 +93,7 @@ function Router() {
       <Route
         path={routes.AGGREGATE}
         element={
-          <PrivateRoute roles={[Permission.API_KEY_READ]}>
+          <PrivateRoute roles={[]}>
             <AggregateDetailPage />
           </PrivateRoute>
         }
@@ -101,7 +101,7 @@ function Router() {
       <Route
         path={routes.ADD_PA}
         element={
-          <PrivateRoute roles={[Permission.API_KEY_READ]}>
+          <PrivateRoute roles={[]}>
             <AssociationPage />
           </PrivateRoute>
         }
@@ -109,7 +109,7 @@ function Router() {
       <Route
         path={routes.TRANSFER_PA}
         element={
-          <PrivateRoute roles={[Permission.API_KEY_READ]}>
+          <PrivateRoute roles={[]}>
             <PaTransferListPage />
           </PrivateRoute>
         }
@@ -119,7 +119,7 @@ function Router() {
         <Route
             path={TENDER_DETAIL_ROUTE}
             element={
-                <PrivateRoute roles={[Permission.API_KEY_READ]}>
+                <PrivateRoute roles={[]}>
                     <TenderDetailPage />
                 </PrivateRoute>
             }

--- a/src/navigation/Router.tsx
+++ b/src/navigation/Router.tsx
@@ -12,6 +12,7 @@ import AggregateDetailPage from "../pages/aggregates/AggregateDetailPage";
 import AssociationPage from "../pages/paAssociation/PaAssociationPage";
 import PaTransferListPage from "../pages/paTransfer/PaTransferListPage";
 import * as routes from "./routes";
+import { Permission } from "../model/user-permission";
 /**
  * Create the routing of the page
  */
@@ -29,7 +30,7 @@ function Router() {
       <Route
         path="/search"
         element={
-          <PrivateRoute condition="token">
+          <PrivateRoute roles={[Permission.API_KEY_READ]}>
             <SearchPage />
           </PrivateRoute>
         }
@@ -38,20 +39,20 @@ function Router() {
       <Route
         path={TENDERS_TABLE_ROUTE}
         element={
-          <PrivateRoute condition="token">
+          <PrivateRoute roles={[Permission.API_KEY_READ]}>
             <TenderPage />
           </PrivateRoute>
         }
       />
       <Route path={CREATE_TENDER_ROUTE}>
         <Route path=":tenderCode" element={
-          <PrivateRoute condition="token">
+          <PrivateRoute roles={[Permission.API_KEY_READ]}>
             <FormTenderPage />
           </PrivateRoute>}
         />
 
         <Route path="" element={
-          <PrivateRoute condition="token">
+          <PrivateRoute roles={[Permission.API_KEY_READ]}>
             <FormTenderPage />
           </PrivateRoute>}
         />
@@ -60,7 +61,7 @@ function Router() {
       <Route
         path={CREATE_TENDER_ROUTE}
         element={
-          <PrivateRoute condition="token">
+          <PrivateRoute roles={[Permission.API_KEY_READ]}>
             <FormTenderPage />
           </PrivateRoute>
         }
@@ -68,7 +69,7 @@ function Router() {
       <Route
         path="/monitoring"
         element={
-          <PrivateRoute condition="token">
+          <PrivateRoute roles={[Permission.API_KEY_READ]}>
             <MonitorPage />
           </PrivateRoute>
         }
@@ -76,7 +77,7 @@ function Router() {
       <Route
         path={routes.AGGREGATES}
         element={
-          <PrivateRoute condition="token">
+          <PrivateRoute roles={[Permission.API_KEY_READ]}>
             <AggregatesPage />
           </PrivateRoute>
         }
@@ -84,7 +85,7 @@ function Router() {
       <Route
         path={routes.UPDATE_AGGREGATE}
         element={
-          <PrivateRoute condition="token">
+          <PrivateRoute roles={[Permission.API_KEY_READ]}>
             <AggregateDetailPage />
           </PrivateRoute>
         }
@@ -92,7 +93,7 @@ function Router() {
       <Route
         path={routes.AGGREGATE}
         element={
-          <PrivateRoute condition="token">
+          <PrivateRoute roles={[Permission.API_KEY_READ]}>
             <AggregateDetailPage />
           </PrivateRoute>
         }
@@ -100,7 +101,7 @@ function Router() {
       <Route
         path={routes.ADD_PA}
         element={
-          <PrivateRoute condition="token">
+          <PrivateRoute roles={[Permission.API_KEY_READ]}>
             <AssociationPage />
           </PrivateRoute>
         }
@@ -108,7 +109,7 @@ function Router() {
       <Route
         path={routes.TRANSFER_PA}
         element={
-          <PrivateRoute condition="token">
+          <PrivateRoute roles={[Permission.API_KEY_READ]}>
             <PaTransferListPage />
           </PrivateRoute>
         }
@@ -118,7 +119,7 @@ function Router() {
         <Route
             path={TENDER_DETAIL_ROUTE}
             element={
-                <PrivateRoute condition="token">
+                <PrivateRoute roles={[Permission.API_KEY_READ]}>
                     <TenderDetailPage />
                 </PrivateRoute>
             }


### PR DESCRIPTION
### Aim
To allow the handling of a well-known set of permissions (defined in https://pagopa.atlassian.net/wiki/spaces/PN/pages/627704430/Formalizzazione+e+dettaglio+ruoli+di+back+office#Elenco-Ruoli), providing an easy way to check whether the logged user has a certain permission (or set of permissions).  
We also define a way to easily access the data about the logged user as stored in Cognito, that includes the set of permissions and also other data (at the moment, only the email address).

### Changes in the codebase
- Added a context to store user data in a way accessible by any component.
- Defined a `useCurrentUser` hook to ease access to the user data.
- Defined a `useHasPermission` hook to ease the permission verification.`
- Changed the `PrivateRoute` component so that it accepts a list of permissions that it verifies through `useHasPermission`.
- The `Header` component obtains the user email through the `useCurrentUser` hook instead of invoking Cognito each time.
- Store the user data including permissions as part of the login procedure.
- Provided a way to store the user data on the event of page reload, this was added to `App.tsx`.
- We obtain user data from the user object handled by Cognito, so that we avoid an additional API call.

### How to test
Enter the app, the permissions can be seen in the Component option which is part of React dev tools, on the `UserContextProvider` element.
![image](https://user-images.githubusercontent.com/5519535/223689078-6e4613a1-9e56-441b-b805-2d7d0f394bac.png)

At the moment, all the routes are assigned an empty list of permissions, so all of them are accessible by any logged user.

**NB**  
At the moment, there is no user with proper permissions set. 